### PR TITLE
商品ステータス変更

### DIFF
--- a/app/Http/Controllers/ItemsController.php
+++ b/app/Http/Controllers/ItemsController.php
@@ -69,6 +69,14 @@ class ItemsController extends Controller
 
         $item->update();
 
-        return redirect('/items');
+        return redirect('items');
+    }
+    public function update_status(Request $request){
+        $item = \App\item::find($request->id);
+        $item->status = $request->status;
+
+        $item->update();
+
+        return redirect('items');
     }
 }

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -67,12 +67,13 @@
                 <th>商品名</th> 
                 <th>価格</th>
                 <th>在庫数</th>
+                <th>商品ステータス</th>
                 <th>商品削除</th>
             </tr>
         </thead>
         <tbody>
             @forelse($items as $item)
-                @if($item->status === 0)
+                @if($item->status === 0 or 1)
                 <tr>
                     <td>
                         <div class="item__image">
@@ -86,9 +87,23 @@
                     <td>
                         <form method="post" action="{{url('/update_item')}}">
                             {{ csrf_field() }}
-                            <input type="text" value="{{ $item->stock }}" name="stock">
+                            <input type="text" name="stock" value="{{ $item->stock }}">
                             <input type="hidden" name="id" value="{{ $item->id }}">
                             <input type="submit" value="在庫数変更" class="btn btn-primary">
+                        </form>
+                    </td>
+                    <td>
+                        <form method="post" action="{{url('/update_status')}}">
+                            {{ csrf_field() }}
+                            @if($item->status === 0)
+                                <input type="hidden" name="status" value=1>
+                                <input type="hidden" name="id" value="{{ $item->id }}">
+                                <input type="submit" value="公開">
+                            @elseif($item->status === 1)
+                                <input type="hidden" name="status" value=0>
+                                <input type="hidden" name="id" value="{{ $item->id }}">
+                                <input type="submit" value="非公開">
+                            @endif
                         </form>
                     </td>
                     <td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,3 +26,5 @@ Auth::routes();
 Route::get('/home', 'HomeController@index')->name('home');
 
 Route::post('/update_item', 'ItemsController@update');
+
+Route::post('/update_status', 'ItemsController@update_status');


### PR DESCRIPTION
商品管理画面に商品ステータスを変更する機能を追加。
加えて、商品ステータスが非公開のものは非表示にしていたが、表示するよう変更。
さらに、ログイン時に商品管理画面へ遷移しなかったエラーを改善。